### PR TITLE
Fix sort with empty cell order

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -364,6 +364,7 @@
     <ProjectReference Include="..\ReoGrid\ReoGrid.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -33,7 +33,7 @@ namespace unvell.ReoGrid.Demo
 
 			Application.SetCompatibleTextRenderingDefault(false);
 
-			Application.Run(new ReoGridWrapperForm());
+			Application.Run(new DemoItemsForm());
 
 			//BorderPainter.Instance.Dispose();
 			//ResourcePoolManager.Instance.Dispose();

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -33,7 +33,7 @@ namespace unvell.ReoGrid.Demo
 
 			Application.SetCompatibleTextRenderingDefault(false);
 
-			Application.Run(new DemoItemsForm());
+			Application.Run(new ReoGridWrapperForm());
 
 			//BorderPainter.Instance.Dispose();
 			//ResourcePoolManager.Instance.Dispose();

--- a/Demo/ReoGridWrapperForm.Designer.cs
+++ b/Demo/ReoGridWrapperForm.Designer.cs
@@ -1,0 +1,85 @@
+﻿
+namespace unvell.ReoGrid.Demo
+{
+    partial class ReoGridWrapperForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.button1 = new System.Windows.Forms.Button();
+            this.panel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.button1);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(800, 100);
+            this.panel1.TabIndex = 0;
+            // 
+            // panel2
+            // 
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel2.Location = new System.Drawing.Point(0, 100);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(800, 350);
+            this.panel2.TabIndex = 1;
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(158, 43);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(106, 28);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "Append Row";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // ReoGridWrapperForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.panel2);
+            this.Controls.Add(this.panel1);
+            this.Name = "ReoGridWrapperForm";
+            this.Text = "ReoGridWrapperForm";
+            this.panel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Button button1;
+    }
+}

--- a/Demo/ReoGridWrapperForm.cs
+++ b/Demo/ReoGridWrapperForm.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using MoreLinq;
+using unvell.ReoGrid.CellTypes;
+using unvell.ReoGrid.Data;
+using unvell.ReoGrid.DataFormat;
+
+namespace unvell.ReoGrid.Demo
+{
+    public partial class ReoGridWrapperForm : Form
+    {
+        private IEnumerable<DataItem> _data = new List<DataItem>
+        {
+            new DataItem {Name = "Name A", Value = 0.62f, IsSelected = true, Type = Types.A},
+            new DataItem {Name = "Name B", Value = 0.85f, IsSelected = false, Type = Types.B},
+            new DataItem {Name = "Name C", Value = 12.56f, IsSelected = true, Type = Types.C},
+            new DataItem {Name = "Name D", Value = -10.37f, IsSelected = true, Type = Types.D},
+            new DataItem {Name = "Name E", Value = 10.32f, IsSelected = true, Type = Types.E},
+            new DataItem {Name = "Name F", Value = 6.71f, IsSelected = true, Type = Types.F},
+            new DataItem {Name = "Name G", Value = -7.58f, IsSelected = true, Type = Types.G},
+        };
+
+        private AutoColumnFilter _selectionFilter;
+        private ReoGridControl _table;
+
+        public ReoGridWrapperForm()
+        {
+            InitializeComponent();
+
+            _table = new ReoGridControl {Dock = DockStyle.Fill};
+            _table.SetSettings(WorkbookSettings.View_ShowSheetTabControl, false);
+            _table.CurrentWorksheet.DisableSettings(WorksheetSettings.View_AllowCellTextOverflow);
+
+            panel2.Controls.Add(_table);
+            _table.Dock = DockStyle.Fill;
+
+            LoadData(_table.Worksheets.First());
+            _selectionFilter = _table.Worksheets.First().CreateColumnFilter(RangePosition.EntireRange);
+        }
+
+        private void LoadData(Worksheet worksheet)
+        {
+            var j = 0;
+            worksheet.DeleteRows(0, worksheet.ColumnCount);
+
+            _data.ForEach((item, i) =>
+            {
+                worksheet.AppendRows(1);
+                worksheet[i, 0] = item.Name;
+                worksheet[i, 1] = item.IsSelected;
+                //worksheet[i, 1] = new CheckBoxCell();
+                worksheet[i, 2] = item.Type;
+
+                if (i == 2)
+                    worksheet.Cells[i, 2].IsReadOnly = true;
+
+                //if (i % 2 == 0)
+                    worksheet[i, 2] = new DropdownListCell(Enum.GetNames(typeof(Types)).Except(new []{item.Type.ToString()}));
+                worksheet[i, 3] = item.Value;
+                j = i;
+            });
+            //worksheet[3, 0] = new string[worksheet.ColumnCount];
+            worksheet[j++, 0] = Enumerable.Repeat(string.Empty, worksheet.ColumnCount).ToArray();
+            // worksheet[3, 1] = string.Empty;
+            // worksheet[3, 1] = new CheckBoxCell();
+            // worksheet[3, 2] = string.Empty;
+            // worksheet[3, 2] = new DropdownListCell(Enum.GetNames(typeof(Types)));
+            // worksheet[3, 3] = string.Empty;
+
+            worksheet.SetCols(4);
+            worksheet.SetRows(j);
+
+            var numberFormatArgs = new NumberDataFormatter.NumberFormatArgs {DecimalPlaces = 2};
+            worksheet.SetRangeDataFormat(new RangePosition(0, 3, -1, 1), CellDataFormatFlag.Number, numberFormatArgs);
+        }
+
+        private class DataItem
+        {
+            public string Name { get; set; }
+            public bool IsSelected { get; set; }
+            public float Value { get; set; }
+            public Types Type { get; set; }
+        }
+
+        private enum Types
+        {
+            A,
+            B,
+            C,
+            D,
+            E,
+            F,
+            G
+        }
+
+        private void button1_Click(object sender, System.EventArgs e)
+        {
+            var worksheet = _table.Worksheets.First();
+            var elderCount = worksheet.RowCount;
+            worksheet.AppendRows(1);
+            worksheet[elderCount, 0] = Enumerable.Repeat(string.Empty, worksheet.ColumnCount).ToArray();
+            _selectionFilter.RefreshApplyRange(RangePosition.EntireRange);
+        }
+
+        /*private void cb_Selected_CheckedChanged(object sender, System.EventArgs e)
+        {
+            var isSelected = sender as CheckBox;
+
+            if (isSelected.Checked)
+            {
+                _selectionFilter.Columns[1].SelectedTextItems.Clear();
+                _selectionFilter.Columns[1].SelectedTextItems.Add("True");
+                var body = _selectionFilter.Columns[1];
+                _selectionFilter.Apply();
+            }
+            else
+            {
+                _selectionFilter.Columns[1].IsSelectAll = true;
+                _selectionFilter.Apply();
+            }
+        }
+
+        private void llb_ClearFilter_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            _selectionFilter.Columns.ForEach(filter =>
+            {
+                filter.SelectedTextItems.Clear();
+                filter.SelectedTextItems.AddRange(filter.GetDistinctItems());
+                filter.IsSelectAll = true;
+                filter.OnDataChange(0, 0);
+            });
+            _selectionFilter.Apply();
+        }*/
+    }
+}

--- a/Demo/ReoGridWrapperForm.resx
+++ b/Demo/ReoGridWrapperForm.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ReoGrid/CellTypes/DropdownCell.cs
+++ b/ReoGrid/CellTypes/DropdownCell.cs
@@ -206,10 +206,16 @@ namespace unvell.ReoGrid.CellTypes
 			base.OnPaint(dc);
 
 			// draw button surface
-			this.OnPaintDropdownButton(dc, this.dropdownButtonRect);
+
+            if (IsSelected())
+            {
+    			this.OnPaintDropdownButton(dc, this.dropdownButtonRect);
+            }
 		}
 
-		/// <summary>
+        private bool IsSelected() => sheet?.selectionRange.StartPos == Cell.Position;
+
+        /// <summary>
 		/// Draw the drop-down button surface.
 		/// </summary>
 		/// <param name="dc">ReoGrid cross-platform drawing context.</param>
@@ -238,7 +244,7 @@ namespace unvell.ReoGrid.CellTypes
 		/// <returns></returns>
 		public override bool OnMouseDown(CellMouseEventArgs e)
 		{
-			if (PullDownOnClick || dropdownButtonRect.Contains(e.RelativePosition))
+			if (PullDownOnClick || dropdownButtonRect.Contains(e.RelativePosition) && IsSelected())
 			{
 				if (this.isDropdown)
 				{
@@ -262,7 +268,7 @@ namespace unvell.ReoGrid.CellTypes
 		/// <returns>True if event has been handled; Otherwise return false.</returns>
 		public override bool OnMouseMove(CellMouseEventArgs e)
 		{
-			if (dropdownButtonRect.Contains(e.RelativePosition))
+			if (IsSelected() && dropdownButtonRect.Contains(e.RelativePosition))
 			{
 				e.CursorStyle = CursorStyle.Hand;
 				return true;
@@ -301,7 +307,7 @@ namespace unvell.ReoGrid.CellTypes
 			return false;
 		}
 
-		private Worksheet sheet;
+		private Worksheet sheet => base.Cell == null ? null : (base.Cell.Worksheet);
 
 		/// <summary>
 		/// Push down to open the dropdown panel.
@@ -314,8 +320,6 @@ namespace unvell.ReoGrid.CellTypes
 			{
 				return;
 			}
-
-			sheet = base.Cell == null ? null : (base.Cell.Worksheet);
 
 			if (sheet != null && this.DropdownControl != null
 				&& Views.CellsViewport.TryGetCellPositionToControl(sheet.ViewportController.FocusView, this.Cell.InternalPos, out var p))

--- a/ReoGrid/CellTypes/DropdownCell.cs
+++ b/ReoGrid/CellTypes/DropdownCell.cs
@@ -213,7 +213,12 @@ namespace unvell.ReoGrid.CellTypes
             }
 		}
 
-        private bool IsSelected() => sheet?.selectionRange.StartPos == Cell.Position;
+        private bool IsSelected()
+        {
+            var startPos = sheet?.selectionRange.StartPos;
+            var cellPos = Cell?.Position;
+            return startPos != null && cellPos != null && startPos == cellPos;
+        }
 
         /// <summary>
 		/// Draw the drop-down button surface.

--- a/ReoGrid/CellTypes/IHeaderBody.cs
+++ b/ReoGrid/CellTypes/IHeaderBody.cs
@@ -40,8 +40,11 @@ namespace unvell.ReoGrid.CellTypes
 	/// Represent the interface of row and column header body
 	/// </summary>
 	public interface IHeaderBody
-	{
-		/// <summary>
+    {
+        Rectangle GetHeadBodyRect(Size headerSize);
+
+        /// <summary>
+        /// 
 		/// Onwer drawing
 		/// </summary>
 		/// <param name="dc">Drawing context</param>
@@ -76,8 +79,10 @@ namespace unvell.ReoGrid.CellTypes
 	/// Represent the interface of row and column header body
 	/// </summary>
 	public class HeaderBody : IHeaderBody
-	{
-		/// <summary>
+    {
+        public Rectangle GetHeadBodyRect(Size headerSize) => new Rectangle();
+
+        /// <summary>
 		/// Paint this header body.
 		/// </summary>
 		/// <param name="dc">Drawing context</param>

--- a/ReoGrid/Core/FilterSort.cs
+++ b/ReoGrid/Core/FilterSort.cs
@@ -491,11 +491,9 @@ namespace unvell.ReoGrid
 					if (top >= bottom) break;
 
 					for (int col = startColumn; col <= endColumn; col++)
-					{
-						var v = GetCellData(top, col);
-						SetCellData(top, col, GetCellData(bottom, col));
-						SetCellData(bottom, col, v);
-					}
+                    {
+                        SwitchCell(top, col, bottom);
+                    }
 
 					if (affectRange.IsEmpty)
 					{
@@ -520,7 +518,18 @@ namespace unvell.ReoGrid
 			}
 		}
 
-		/// <summary>
+        private void SwitchCell(int top, int col, int bottom)
+        {
+            var v = GetCellData(top, col);
+            SetCellData(top, col, GetCellData(bottom, col));
+            SetCellData(bottom, col, v);
+
+            var cellBody = Cells[top, col].body;
+            Cells[top, col].body = Cells[bottom, col].body;
+            Cells[bottom, col].body = cellBody;
+        }
+
+        /// <summary>
 		/// Event raised when rows sorted on this worksheet.
 		/// </summary>
 		public event EventHandler<Events.RangeEventArgs> RowsSorted;

--- a/ReoGrid/Core/FilterSort.cs
+++ b/ReoGrid/Core/FilterSort.cs
@@ -550,9 +550,11 @@ namespace unvell.ReoGrid
             SetCellData(top, col, GetCellData(bottom, col));
             SetCellData(bottom, col, v);
 
-            var cellBody = Cells[top, col].body;
-            Cells[top, col].body = Cells[bottom, col].body;
-            Cells[bottom, col].body = cellBody;
+            var topCellBody = Cells[top, col].body;
+            var bottomCellBody = Cells[bottom, col].body;
+
+            Cells[top, col].Body = bottomCellBody?.Clone();
+            Cells[bottom, col].Body = topCellBody?.Clone();
         }
 
         /// <summary>

--- a/ReoGrid/Data/AutoFilter.cs
+++ b/ReoGrid/Data/AutoFilter.cs
@@ -231,7 +231,12 @@ namespace unvell.ReoGrid.Data
 
 			internal bool IsDropdown { get; set; }
 
-			/// <summary>
+            public Rectangle GetHeadBodyRect(Size headerSize)
+            {
+                return GetColumnFilterButtonRect(headerSize);
+            }
+
+            /// <summary>
 			/// Repaint filter header body
 			/// </summary>
 			/// <param name="dc">ReoGrid drawing context</param>

--- a/ReoGrid/Views/Header/ColumnHeaderView.cs
+++ b/ReoGrid/Views/Header/ColumnHeaderView.cs
@@ -97,7 +97,9 @@ namespace unvell.ReoGrid.Views
 						textBrush = headerTextBrush;
 					}
 
-					r.DrawHeaderText(header.RenderText, textBrush, rect);
+                    var headBodyRect = header.Body?.GetHeadBodyRect(new Size(header.InnerWidth * this.scaleFactor, sheet.colHeaderHeight));
+                    var rectangle = new Rectangle(rect.Location, new Size(rect.Width - (headBodyRect?.Width ?? 0), rect.Height));
+                    r.DrawHeaderText(header.RenderText, textBrush, rectangle);
 
 					if (header.Body != null)
 					{


### PR DESCRIPTION
- Not only switch cell value but also cell body when sorting.
- Always put the empty string to the bottom of the list when sorting.
- Dropdown cell only show the dropdown button when it is focused.
- Use default DemoItemsForm in Demo project
- Consider column filter header when rendering column header text.
- Fix the error that the cell body is wrong after sorting.