### PR TITLE
Use the cell position that has been fixed

### DIFF
--- a/ReoGrid/Core/Worksheet/Selection.cs
+++ b/ReoGrid/Core/Worksheet/Selection.cs
@@ -1406,7 +1406,7 @@ namespace unvell.ReoGrid
 
 			if (cell != null)
 			{
-				cell = GetMergedCellOfRange(pos.Row, selEnd.Col);
+				cell = GetMergedCellOfRange(pos.Row, pos.Col);
 				pos = cell.Position;
 			}
 
@@ -1444,7 +1444,7 @@ namespace unvell.ReoGrid
 
 			if (cell != null)
 			{
-				cell = GetMergedCellOfRange(pos.Row, selEnd.Col);
+				cell = GetMergedCellOfRange(pos.Row, pos.Col);
 				pos = cell.Position;
 			}
 


### PR DESCRIPTION
When selecting an entire row, selEnd.Col includes invisible columns, which can cause it to exceed the range of cells. This leads to an ArgumentOutOfRangeException being thrown when calling GetMergedCellOfRange. To avoid this issue, use the cell position that has been corrected by the FixPos method.